### PR TITLE
Fix constant anti-pattern

### DIFF
--- a/src/main/java/com/bizao/gestionvol/controllers/api/CompanyAPI.java
+++ b/src/main/java/com/bizao/gestionvol/controllers/api/CompanyAPI.java
@@ -15,6 +15,7 @@ import javax.validation.Valid;
 import java.util.List;
 
 import static com.bizao.gestionvol.utils.Constants.API_ROOT;
+
 public interface CompanyAPI
 {
     @PostMapping(

--- a/src/main/java/com/bizao/gestionvol/utils/Constants.java
+++ b/src/main/java/com/bizao/gestionvol/utils/Constants.java
@@ -1,6 +1,10 @@
 package com.bizao.gestionvol.utils;
 
-public interface Constants
+public class Constants
 {
-    public static String API_ROOT = "gestionvol/v1";
+    private Constants()
+    {
+    }
+
+    public static final String API_ROOT = "gestionvol/v1";
 }


### PR DESCRIPTION
Found an **constant anti-pattern**. 

Refer to [this](https://www.baeldung.com/java-constants-good-practices) site for more details on this. 

Why not use an interface? 

- Using an interface as a constant class goes against the purpose of an interface. 
- it could have been understandable if you implemented the interface on every class you called the constant but in your case you did not
- It is apparent that the current change done match what you had intended. 

**Note** that because we have a private constructor, the class cannot be extended. So there will not be a need of having the final keyword as shown in the page I just pointed you to. 